### PR TITLE
Custom configuration options and server listen addresses

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -17,6 +17,6 @@ jobs:
         run: pip3 install -r .dev_requirements.txt
 
       - name: Test playbook
-        run: molecule test -- -e opencast_postgresql_password=123
+        run: molecule test
         env:
           PY_COLORS: '1'

--- a/README.md
+++ b/README.md
@@ -20,14 +20,21 @@ Role Variables
 - `opencast_postgresql_version`
 	- PostgreSQL major version to install (default: `12`)
 	- Enables CentOS AppStream
-- `opencast_postgresql_user:`
+- `opencast_postgresql_user`
 	- Database user to create (default: `opencast`)
 - `opencast_postgresql_password`
 	- Databse password for user (_required_)
 - `opencast_postgresql_database`
 	- Database name (default: `opencast`)
+- `opencast_postgresql_listen_addresses`
+	- List of IP addresses the server should listen on (default: `["localhost"]`).
+	- Use `*` to listen on all IP addresses.
+	- For more information please consult PostgreSQL documentation for the configuration `listen_addresses`
 - `opencast_postgresql_connection_hosts`
-	- List of hosts allowed to connect to database (default: `[127.0.0.1/32, ::1/128]`)
+	- List of IP ranges allowed to connect to database (default: `[127.0.0.1/32, ::1/128]`)
+- `opencast_postgresql_extra_configs`
+	- Additional server configurations as dictionary (default: `{}`)
+	- Please consult PostgreSQL documentation for available configurations
 
 
 Example Playbook
@@ -41,4 +48,23 @@ Example of how to configure and use the role:
   roles:
     - role: elan.opencast_postgresql
       opencast_postgresql_password: secret
+```
+
+More complex example with custom configurations and listening on all IP addresses is shown here:
+
+```yaml
+- hosts: servers
+  become: true
+  roles:
+    - role: elan.opencast_postgresql
+      opencast_postgresql_password: secret
+      opencast_postgresql_extra_configs:
+        max_connections: 1000        # Increased value for production use
+        log_destination: "'syslog'"  # Log to syslog
+      opencast_postgresql_listen_addresses:
+        - "*"                        # Listen on all IP addresses
+      opencast_postgresql_connection_hosts:
+        - "127.0.0.1/32"
+        - "::1/128"
+        - "10.10.10.1/24"            # Clients IP range
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@
 opencast_postgresql_version: 16
 opencast_postgresql_user: opencast
 opencast_postgresql_database: opencast
+opencast_postgresql_listen_addresses:
+  - "localhost"
 opencast_postgresql_connection_hosts:
   - 127.0.0.1/32
   - ::1/128
+opencast_postgresql_extra_configs: {}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,7 +1,16 @@
 ---
+
 - name: Converge
   hosts: all
-  tasks:
-    - name: "Include opencast_postgresql"
-      ansible.builtin.include_role:
-        name: elan.opencast_postgresql
+  roles:
+    - role: elan.opencast_postgresql
+      opencast_postgresql_password: secret
+      opencast_postgresql_extra_configs:
+        max_connections: 1000        # Increase value for production use
+        log_destination: "'syslog'"  # Log to syslog
+      opencast_postgresql_listen_addresses:
+        - "*"                        # Listen on all IP addresses
+      opencast_postgresql_connection_hosts:
+        - "127.0.0.1/32"
+        - "::1/128"
+        - "10.10.10.1/24"            # Clients IP range

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -39,3 +39,34 @@
       ansible.builtin.debug:
         msg: "PostgreSQL version on {{ inventory_hostname }} (Debian): {{ psql_version_debian.stdout }}"
       when: ansible_os_family == "Debian"
+
+    - name: Find configuration file
+      ansible.builtin.set_fact:
+        config_file_dir: "{{ paths[ansible_os_family] }}"
+      vars:
+        paths:
+          RedHat: "/var/lib/pgsql/{{ opencast_postgresql_version }}/data"
+          Debian: "/etc/postgresql/{{ opencast_postgresql_version }}/main"
+
+    - name: Read configuration file
+      ansible.builtin.slurp:
+        src: "{{ config_file_dir }}/postgresql.conf"
+      register: config_file
+
+    - name: Test config set
+      ansible.builtin.assert:
+        that:
+          - '"listen_addresses = ''*''" in (config_file.content | b64decode)'
+          - '"max_connections = 1000" in (config_file.content | b64decode)'
+          - '"log_destination = ''syslog''" in (config_file.content | b64decode)'
+
+    - name: Read pg_hba.conf configuration file
+      ansible.builtin.slurp:
+        src: "{{ config_file_dir }}/pg_hba.conf"
+      register: hba_config_file
+
+    - name: Test config set
+      ansible.builtin.assert:
+        that:
+          - '"host    all             all             127.0.0.1/32            scram-sha-256" in (hba_config_file.content | b64decode)'
+          - '"host    all             all             10.10.10.1/24            scram-sha-256" in (hba_config_file.content | b64decode)'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,23 @@
   notify: Restart Postgresql On CentOS
   when: ansible_os_family == "RedHat"
 
+- name: Set listen_addresses (CentOS/RHEL)
+  ansible.builtin.lineinfile:
+    path: "/var/lib/pgsql/{{ opencast_postgresql_version }}/data/postgresql.conf"
+    regexp: '#?\s*listen_addresses\s*='
+    line: "listen_addresses = '{{ opencast_postgresql_listen_addresses | join(', ') }}'"
+  notify: Restart Postgresql On CentOS
+  when: ansible_os_family == "RedHat"
+
+- name: Set extra configs (CentOS/RHEL)
+  ansible.builtin.lineinfile:
+    path: "/var/lib/pgsql/{{ opencast_postgresql_version }}/data/postgresql.conf"
+    regexp: '#?\s*{{ item.key }}\s*='
+    line: "{{ item.key }} = {{ item.value }}"
+  loop: "{{ opencast_postgresql_extra_configs | dict2items }}"
+  notify: Restart Postgresql On CentOS
+  when: ansible_os_family == "RedHat"
+
 - name: Start and enable PostgreSQL (CentOS/RHEL)
   ansible.builtin.service:
     name: "postgresql-{{ opencast_postgresql_version }}"
@@ -116,6 +133,23 @@
     owner: postgres
     group: postgres
     mode: "0644"
+  notify: Restart Postgresql On Debian/Ubuntu
+  when: ansible_os_family == "Debian"
+
+- name: Set listen_addresses (Debian/Ubuntu)
+  ansible.builtin.lineinfile:
+    path: "/etc/postgresql/{{ opencast_postgresql_version }}/main/postgresql.conf"
+    regexp: '#?\s*listen_addresses\s*='
+    line: "listen_addresses = '{{ opencast_postgresql_listen_addresses | join(', ') }}'"
+  notify: Restart Postgresql On Debian/Ubuntu
+  when: ansible_os_family == "Debian"
+
+- name: Set extra configs (Debian/Ubuntu)
+  ansible.builtin.lineinfile:
+    path: "/etc/postgresql/{{ opencast_postgresql_version }}/main/postgresql.conf"
+    regexp: '#?\s*{{ item.key }}\s*='
+    line: "{{ item.key }} = {{ item.value }}"
+  loop: "{{ opencast_postgresql_extra_configs | dict2items }}"
   notify: Restart Postgresql On Debian/Ubuntu
   when: ansible_os_family == "Debian"
 


### PR DESCRIPTION
It is now possible to customize PostgreSQL configuration with role vars. The listen_addresses configuration can be set as a separate variable.