### PR TITLE
Add automated backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 .ansible/
+.idea

--- a/README.md
+++ b/README.md
@@ -17,17 +17,42 @@ ansible-galaxy collection install community.postgresql
 Role Variables
 --------------
 
+#### Variables for installing the Database
 - `opencast_postgresql_version`
-	- PostgreSQL major version to install (default: `12`)
+	- PostgreSQL major version to install (default: `16`)
 	- Enables CentOS AppStream
-- `opencast_postgresql_user:`
+- `opencast_postgresql_user`
 	- Database user to create (default: `opencast`)
 - `opencast_postgresql_password`
-	- Databse password for user (_required_)
+	- Database password for user (_required_)
 - `opencast_postgresql_database`
 	- Database name (default: `opencast`)
 - `opencast_postgresql_connection_hosts`
 	- List of hosts allowed to connect to database (default: `[127.0.0.1/32, ::1/128]`)
+
+#### (Optional) Variables for configuring automated Database Backups
+- `database_backup_enabled`
+  - Activate database backups (default: `false`)
+- `database_backup_output_path`
+  - Directory for the the backup files (default: `""`)
+  - _**required**_ when backups are enabled
+- `database_backup_schedule`
+  - Schedule for the backup creation (default: `*-*-* 05:00:00`)
+  - Uses Systemd OnCalendar format
+- `database_backup_keep`
+  - How many backups to keep, oldest will be cleaned up (default: `7`)
+- `database_backup_dbs`
+  - define which PostgreSQL databases should be backuped (default: `{{ opencast_postgresql_database }}`)
+  - Expects a list of database names, but always adds at least the `{{ opencast_postgresql_database }}`
+- `database_backup_owner`
+  - OS owner of the backup directory and files (default: `postgres`)
+- `database_backup_group`
+  - OS group of the backup directory and files (default: `postgres`)
+- `database_backup_user`
+  - Name of the DB User that runs pg_dump (default: `backup`)
+
+
+  
 
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,15 @@ opencast_postgresql_database: opencast
 opencast_postgresql_connection_hosts:
   - 127.0.0.1/32
   - ::1/128
+
+# === Database backup feature (disabled by default) ===
+database_backup_enabled: false
+database_backup_output_path: ""
+database_backup_schedule: "*-*-* 05:00:00"   # Systemd OnCalendar format
+database_backup_keep: 7
+# list of databases
+database_backup_dbs:
+  - "{{ opencast_postgresql_database }}"
+database_backup_owner: postgres
+database_backup_group: postgres
+database_backup_user: backup

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,7 +1,14 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    opencast_postgresql_password: "1234"
+    database_backup_user_password: "4321"
+    database_backup_enabled: true
+    database_backup_output_path: "/var/tmp/db_backups"
+    database_backup_schedule: "*-*-* *:*:00"   # Systemd OnCalendar format
+    database_backup_keep: 4
   tasks:
-    - name: "Include opencast_postgresql"
+    - name: Include opencast_postgresql
       ansible.builtin.include_role:
         name: elan.opencast_postgresql

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,11 +1,14 @@
 ---
-- name: Verify PostgreSQL Installation
+- name: Verify PostgreSQL Installation & Backup Configuration
   hosts: all
   gather_facts: true
   vars_files:
     - ../../defaults/main.yml
 
   tasks:
+    # ───────────────────────────────────────────────────────────
+    # Basic PostgreSQL installation
+    # ───────────────────────────────────────────────────────────
     - name: Ensure PostgreSQL service is running on RedHat/CentOS
       ansible.builtin.systemd:
         name: "postgresql-{{ opencast_postgresql_version }}"
@@ -39,3 +42,51 @@
       ansible.builtin.debug:
         msg: "PostgreSQL version on {{ inventory_hostname }} (Debian): {{ psql_version_debian.stdout }}"
       when: ansible_os_family == "Debian"
+
+    # ───────────────────────────────────────────────────────────
+    # Backup configuration (only when enabled)
+    # ───────────────────────────────────────────────────────────
+    - name: Verify backup configuration when enabled
+      when: database_backup_enabled | default(false)
+      block:
+        - name: Ensure backup directory exists
+          ansible.builtin.stat:
+            path: "{{ database_backup_output_path }}"
+          register: backup_dir_stat
+
+        - name: Assert backup directory is present and writable
+          ansible.builtin.assert:
+            that:
+              - backup_dir_stat.stat.exists
+              - backup_dir_stat.stat.isdir
+            fail_msg: >
+              Backup directory {{ database_backup_output_path }}
+              is missing or not a directory.
+
+        - name: Check database-backup.service is installed and enabled
+          ansible.builtin.systemd:
+            name: database-backup.service
+            enabled: true
+            state: started
+
+        - name: Check database-backup.timer is installed and enabled
+          ansible.builtin.systemd:
+            name: database-backup.timer
+            enabled: true
+            state: started
+
+        - name: Slurp timer unit file for inspection
+          ansible.builtin.slurp:
+            path: /etc/systemd/system/database-backup.timer
+          register: timer_unit
+
+        - name: Assert OnCalendar line in timer unit matches schedule
+          ansible.builtin.assert:
+            that:
+              - "'OnCalendar={{ database_backup_schedule }}' in (timer_unit.content | b64decode)"
+            fail_msg: >
+              database-backup.timer does not contain
+              OnCalendar={{ database_backup_schedule }}.
+            success_msg: >
+              Timer unit file correctly contains
+              OnCalendar={{ database_backup_schedule }}.

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -26,6 +26,7 @@
         name: "{{ database_backup_user }}"
         password: "{{ database_backup_user_password }}"
         role_attr_flags: "NOSUPERUSER,NOCREATEDB"
+      no_log: true
 
     - name: Grant User CONNECT permission to the database
       community.postgresql.postgresql_privs:
@@ -41,7 +42,6 @@
         group: pg_read_all_data
         target_roles: "{{ database_backup_user }}"
         state: present
-      when: database_backup_enabled
 
 - name: Ensure backup output directory exists
   ansible.builtin.file:

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -21,27 +21,27 @@
   become_method: ansible.builtin.su
   when: database_backup_enabled
   block:
-  - name: Create Database User
-    community.postgresql.postgresql_user:
-      name: "{{ database_backup_user }}"
-      password: "{{ database_backup_user_password }}"
-      role_attr_flags: "NOSUPERUSER,NOCREATEDB"
+    - name: Create Database User
+      community.postgresql.postgresql_user:
+        name: "{{ database_backup_user }}"
+        password: "{{ database_backup_user_password }}"
+        role_attr_flags: "NOSUPERUSER,NOCREATEDB"
 
-  - name: Grant User CONNECT permission to the database
-    community.postgresql.postgresql_privs:
-      db: "{{ item }}"
-      role: "{{ database_backup_user }}"
-      objs: "{{ item }}"
-      type: database
-      privs: CONNECT
-    loop: "{{ database_backup_dbs }}"
+    - name: Grant User CONNECT permission to the database
+      community.postgresql.postgresql_privs:
+        db: "{{ item }}"
+        role: "{{ database_backup_user }}"
+        objs: "{{ item }}"
+        type: database
+        privs: CONNECT
+      loop: "{{ database_backup_dbs }}"
 
-  - name: Grant User read-only access to all data
-    community.postgresql.postgresql_membership:
-      group: pg_read_all_data
-      target_roles: "{{ database_backup_user }}"
-      state: present
-    when: database_backup_enabled
+    - name: Grant User read-only access to all data
+      community.postgresql.postgresql_membership:
+        group: pg_read_all_data
+        target_roles: "{{ database_backup_user }}"
+        state: present
+      when: database_backup_enabled
 
 - name: Ensure backup output directory exists
   ansible.builtin.file:

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -15,35 +15,33 @@
     - database_backup_enabled
     - database_backup_user != "root"
 
-- name: Create PostgreSQL backup user
+- name: Create PostgreSQL Backup User
   become: true
   become_user: postgres
-  community.postgresql.postgresql_user:
-    name: "{{ database_backup_user }}"
-    password: "{{ database_backup_user_password }}"
-    role_attr_flags: "NOSUPERUSER,NOCREATEDB"
+  become_method: ansible.builtin.su
   when: database_backup_enabled
+  block:
+  - name: Create Database User
+    community.postgresql.postgresql_user:
+      name: "{{ database_backup_user }}"
+      password: "{{ database_backup_user_password }}"
+      role_attr_flags: "NOSUPERUSER,NOCREATEDB"
 
-- name: Grant CONNECT permission to the database
-  become: true
-  become_user: postgres
-  community.postgresql.postgresql_privs:
-    db: "{{ item }}"
-    role: "{{ database_backup_user }}"
-    objs: "{{ item }}"
-    type: database
-    privs: CONNECT
-  loop: "{{ database_backup_dbs }}"
-  when: database_backup_enabled
+  - name: Grant User CONNECT permission to the database
+    community.postgresql.postgresql_privs:
+      db: "{{ item }}"
+      role: "{{ database_backup_user }}"
+      objs: "{{ item }}"
+      type: database
+      privs: CONNECT
+    loop: "{{ database_backup_dbs }}"
 
-- name: Grant read-only access to all data
-  become: true
-  become_user: postgres
-  community.postgresql.postgresql_membership:
-    group: pg_read_all_data
-    target_roles: "{{ database_backup_user }}"
-    state: present
-  when: database_backup_enabled
+  - name: Grant User read-only access to all data
+    community.postgresql.postgresql_membership:
+      group: pg_read_all_data
+      target_roles: "{{ database_backup_user }}"
+      state: present
+    when: database_backup_enabled
 
 - name: Ensure backup output directory exists
   ansible.builtin.file:

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -1,0 +1,103 @@
+---
+- name: Fail if backup enabled but no output path given
+  ansible.builtin.fail:
+    msg: "database_backup_output_path must be set when database_backup_enabled = true"
+  when:
+    - database_backup_enabled
+    - database_backup_output_path | length == 0
+
+- name: Ensure backup OS user exists
+  ansible.builtin.user:
+    name: "{{ database_backup_owner }}"
+    state: present
+    system: true
+  when:
+    - database_backup_enabled
+    - database_backup_user != "root"
+
+- name: Create PostgreSQL backup user
+  become: true
+  become_user: postgres
+  community.postgresql.postgresql_user:
+    name: "{{ database_backup_user }}"
+    password: "{{ database_backup_user_password }}"
+    role_attr_flags: "NOSUPERUSER,NOCREATEDB"
+  when: database_backup_enabled
+
+- name: Grant CONNECT permission to the database
+  become: true
+  become_user: postgres
+  community.postgresql.postgresql_privs:
+    db: "{{ item }}"
+    role: "{{ database_backup_user }}"
+    objs: "{{ item }}"
+    type: database
+    privs: CONNECT
+  loop: "{{ database_backup_dbs }}"
+  when: database_backup_enabled
+
+- name: Grant read-only access to all data
+  become: true
+  become_user: postgres
+  community.postgresql.postgresql_membership:
+    group: pg_read_all_data
+    target_roles: "{{ database_backup_user }}"
+    state: present
+  when: database_backup_enabled
+
+- name: Ensure backup output directory exists
+  ansible.builtin.file:
+    path: "{{ database_backup_output_path }}"
+    state: directory
+    owner: "{{ database_backup_owner }}"
+    group: "{{ database_backup_group }}"
+    mode: "0750"
+  when: database_backup_enabled
+
+- name: Install backup script
+  ansible.builtin.template:
+    src: database-backup.sh.j2
+    dest: "{{ database_backup_output_path }}/database-backup.sh"
+    owner: "{{ database_backup_owner }}"
+    group: "{{ database_backup_group }}"
+    mode: "0750"
+  when: database_backup_enabled
+
+- name: Install systemd service unit
+  ansible.builtin.template:
+    src: database-backup.service.j2
+    dest: /etc/systemd/system/database-backup.service
+    mode: "0644"
+  when: database_backup_enabled
+  register: database_backup_service_unit
+
+- name: Install systemd timer unit
+  ansible.builtin.template:
+    src: database-backup.timer.j2
+    dest: /etc/systemd/system/database-backup.timer
+    mode: "0644"
+  when: database_backup_enabled
+  register: database_backup_timer_unit
+
+- name: Reload systemd daemon (if timers changed)
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when:
+    - database_backup_enabled
+    - database_backup_service_unit.changed or database_backup_timer_unit.changed
+
+- name: Ensure backup timer is enabled and running
+  ansible.builtin.systemd:
+    name: database-backup.timer
+    enabled: true
+    state: started
+  when: database_backup_enabled
+
+- name: Install restore script
+  ansible.builtin.template:
+    src: database-restore.sh.j2
+    dest: "{{ database_backup_output_path }}/database-restore.sh"
+    owner: "{{ database_backup_owner }}"
+    group: "{{ database_backup_group }}"
+    mode: "0750"
+  when: database_backup_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,12 +26,12 @@
     update_cache: true
   when: ansible_os_family == "RedHat"
 
-- name: Link PostgreSQL {{ opencast_postgresql_version }} binaries to system path
+- name: Link binaries to system path of PostgreSQL {{ opencast_postgresql_version }}
   ansible.builtin.file:
     src: "/usr/pgsql-{{ opencast_postgresql_version }}/bin/{{ item }}"
     dest: "/usr/bin/{{ item }}"
     state: link
-    force: yes
+    force: true
   loop:
     - psql
     - pg_dump
@@ -84,6 +84,8 @@
   when: ansible_os_family == "Debian"
 
 - name: Install PostgreSQL Repository (Debian/Ubuntu)
+  when: ansible_os_family == "Debian"
+  become: true
   block:
     - name: Ensure keyrings directory exists
       ansible.builtin.file:
@@ -103,9 +105,6 @@
         state: present
         filename: postgresql
       register: add_postgres_repo
-  when: ansible_os_family == "Debian"
-  become: true
-
 
 - name: Update apt cache when repo added (Debian/Ubuntu)
   ansible.builtin.apt:
@@ -123,12 +122,12 @@
     update_cache: true
   when: ansible_os_family == "Debian"
 
-- name: Link PostgreSQL {{ opencast_postgresql_version }} binaries to system path
+- name: Link binaries to system path of PostgreSQL {{ opencast_postgresql_version }}
   ansible.builtin.file:
     src: "/usr/lib/postgresql/{{ opencast_postgresql_version }}/bin/{{ item }}"
     dest: "/usr/bin/{{ item }}"
     state: link
-    force: yes
+    force: true
   loop:
     - psql
     - pg_dump

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,19 @@
     update_cache: true
   when: ansible_os_family == "RedHat"
 
+- name: Link PostgreSQL {{ opencast_postgresql_version }} binaries to system path
+  ansible.builtin.file:
+    src: "/usr/pgsql-{{ opencast_postgresql_version }}/bin/{{ item }}"
+    dest: "/usr/bin/{{ item }}"
+    state: link
+    force: yes
+  loop:
+    - psql
+    - pg_dump
+    - pg_dumpall
+    - pg_restore
+  when: ansible_os_family == "RedHat"
+
 - name: Initialise PostgreSQL database (CentOS/RHEL)
   ansible.builtin.command:
     cmd: "/usr/pgsql-{{ opencast_postgresql_version }}/bin/postgresql-{{ opencast_postgresql_version }}-setup initdb"
@@ -70,20 +83,29 @@
     update_cache: true
   when: ansible_os_family == "Debian"
 
-- name: Add PostgreSQL GPG key (Debian/Ubuntu)
-  ansible.builtin.apt_key:
-    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
-    state: present
-  when: ansible_os_family == "Debian"
+- name: Install PostgreSQL Repository (Debian/Ubuntu)
+  block:
+    - name: Ensure keyrings directory exists
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: '0755'
 
-- name: Add PostgreSQL repository (Debian/Ubuntu)
-  ansible.builtin.apt_repository:
-    repo: >-
-      deb http://apt.postgresql.org/pub/repos/apt
-      {{ ansible_distribution_release }}-pgdg main
-    state: present
-  register: add_postgres_repo
+    - name: Download PostgreSQL GPG key
+      ansible.builtin.get_url:
+        url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        dest: /etc/apt/keyrings/postgresql.asc
+        mode: '0644'
+
+    - name: Add PostgreSQL Repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"
+        state: present
+        filename: postgresql
+      register: add_postgres_repo
   when: ansible_os_family == "Debian"
+  become: true
+
 
 - name: Update apt cache when repo added (Debian/Ubuntu)
   ansible.builtin.apt:
@@ -99,6 +121,19 @@
       - acl
     state: present
     update_cache: true
+  when: ansible_os_family == "Debian"
+
+- name: Link PostgreSQL {{ opencast_postgresql_version }} binaries to system path
+  ansible.builtin.file:
+    src: "/usr/lib/postgresql/{{ opencast_postgresql_version }}/bin/{{ item }}"
+    dest: "/usr/bin/{{ item }}"
+    state: link
+    force: yes
+  loop:
+    - psql
+    - pg_dump
+    - pg_dumpall
+    - pg_restore
   when: ansible_os_family == "Debian"
 
 - name: Set auth to scram-sha-256 in postgresql.conf (Debian/Ubuntu)
@@ -145,3 +180,10 @@
   community.postgresql.postgresql_db:
     name: "{{ opencast_postgresql_database }}"
     owner: "{{ opencast_postgresql_user }}"
+
+###############################################################################
+# database backup
+###############################################################################
+- name: Include backup setup tasks
+  ansible.builtin.include_tasks: backup.yml
+  when: database_backup_enabled

--- a/templates/database-backup.service.j2
+++ b/templates/database-backup.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Opencast Database Backup
+After=network.target
+After=local-fs.target
+After=remote-fs.target
+
+[Service]
+Type=oneshot
+User={{ database_backup_owner }}    
+Group={{ database_backup_group }} 
+ExecStart={{ database_backup_output_path }}/database-backup.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/database-backup.sh.j2
+++ b/templates/database-backup.sh.j2
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+DBUSER="{{ database_backup_user }}"
+DBPASS="{{ database_backup_user_password }}"
+OUTDIR="{{ database_backup_output_path }}"
+KEEP={{ database_backup_keep }}
+DBS=({{ database_backup_dbs | join(' ') }})
+TS=$(date +%Y%m%d-%H%M%S)
+
+# Export PostgreSQL password so pg_dump doesn't prompt
+export PGPASSWORD="{{opencast_postgresql_password}}"
+
+# Loop through each database name
+for DB in "${DBS[@]}"; do
+  echo "Backing up $DB → $OUTDIR/db-backup-${DB}-${TS}.dump"
+
+  # Run pg_dump and use -Fc to compress the file
+  pg_dump -Fc -d "$DB" -f "${OUTDIR}/db-backup-${DB}-${TS}.dump"
+
+  # Remove older dumps, keep only the newest $KEEP
+  ls -1t "${OUTDIR}/db-backup-${DB}-"*.dump \
+    | tail -n +$((KEEP + 1)) \
+    | xargs -r rm --
+done

--- a/templates/database-backup.timer.j2
+++ b/templates/database-backup.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run database backup daily
+
+[Timer]
+OnCalendar={{ database_backup_schedule }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/templates/database-restore.sh.j2
+++ b/templates/database-restore.sh.j2
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -o pipefail
+
+# Usage: ./database-restore.sh <database_name> <backup_file>
+
+DB_NAME=$1
+BACKUP_FILE=$2
+CORES=$(nproc)
+
+if [ -z "$DB_NAME" ] || [ -z "$BACKUP_FILE" ]; then
+  echo "Usage: $0 <database_name> <backup_file>"
+  exit 1
+fi
+
+if [ ! -f "$BACKUP_FILE" ]; then
+  echo "Error: Backup file $BACKUP_FILE does not exist."
+  exit 2
+fi
+
+# we don't use the backup user, because we need db creation rights
+export PGUSER="{{ opencast_postgresql_user }}"
+export PGPASSWORD="{{ opencast_postgresql_password }}"
+export PGHOST="localhost"
+
+echo "Restoring database $DB_NAME from $BACKUP_FILE..."
+
+# --force drops the DB even if there are active connections
+dropdb --if-exists --force "$DB_NAME"
+createdb "$DB_NAME"
+
+# Import the backup file
+# -j = number of parallel jobs, increases import speed
+pg_restore -j "$CORES" -d "$DB_NAME" -v "$BACKUP_FILE"
+
+RESULT=$?
+
+# Cleanup
+unset PGUSER
+unset PGPASSWORD
+unset PGHOST
+
+if [ $RESULT -eq 0 ]; then
+  echo "Restore completed successfully."
+else
+  echo "Restore failed."
+  exit 3
+fi


### PR DESCRIPTION
Initial PR from @NUZAT-TABASSUM: #6 

Adds automated backups to the postgresql role. You can define databases, set a schedule and define a path for the backup files. The backups will be triggered by a script and a systemd timer. There is also a script for restoring backups. It will also be deployed, but its intended to be executed manually in case of need.